### PR TITLE
fix for LaTeX Error cslreferences undefined

### DIFF
--- a/inst/rmarkdown/templates/thesis/skeleton/template.tex
+++ b/inst/rmarkdown/templates/thesis/skeleton/template.tex
@@ -204,33 +204,39 @@ $if(dir)$
 \fi
 $endif$
 
-% LS 25-11-2020 add new statement similar to thesisdown bugfix:
-% https://github.com/ismayc/thesisdown/pull/79#issue-384204665
-% LS 25-11-2020 note: fix didn't work: I went to the raw pandoc version and copied and pasted the following lines.
-% copied from https://github.com/jgm/pandoc/blob/master/data/templates/default.latex
+% LCR fix for new required cslreferences environment in pandoc
+% from https://github.com/rstudio/rticles/pull/335/commits/a9937b6
+% originally proposed by LS: https://github.com/LDSamson/amsterdown/commit/4d9841e
+% Pandoc citation processing
 $if(csl-refs)$
-\newlength{\cslhangindent}
-\setlength{\cslhangindent}{1.5em}
 \newlength{\csllabelwidth}
 \setlength{\csllabelwidth}{3em}
-\newenvironment{CSLReferences}[2] % #1 hanging-ident, #2 entry spacing
+\newlength{\cslhangindent}
+\setlength{\cslhangindent}{1.5em}
+% for Pandoc 2.8 to 2.10.1
+\newenvironment{cslreferences}%
+  {$if(csl-hanging-indent)$\setlength{\parindent}{0pt}%
+  \everypar{\setlength{\hangindent}{\cslhangindent}}\ignorespaces$endif$}%
+  {\par}
+% For Pandoc 2.11+
+\newenvironment{CSLReferences}[3] % #1 hanging-ident, #2 entry sp
  {% don't indent paragraphs
   \setlength{\parindent}{0pt}
   % turn on hanging indent if param 1 is 1
   \ifodd #1 \everypar{\setlength{\hangindent}{\cslhangindent}}\ignorespaces\fi
+  % set line spacing
   % set entry spacing
   \ifnum #2 > 0
-  \setlength{\parskip}{#2\baselineskip}
+  \setlength{\parskip}{#3\baselineskip}
   \fi
  }%
  {}
-\usepackage{calc}
+\usepackage{calc} % for \widthof, \maxof
 \newcommand{\CSLBlock}[1]{#1\hfill\break}
-\newcommand{\CSLLeftMargin}[1]{\parbox[t]{\csllabelwidth}{#1}}
-\newcommand{\CSLRightInline}[1]{\parbox[t]{\linewidth - \csllabelwidth}{#1}\break}
+\newcommand{\CSLLeftMargin}[1]{\parbox[t]{\maxof{\widthof{#1}}{\csllabelwidth}}{#1}}
+\newcommand{\CSLRightInline}[1]{\parbox[t]{\linewidth}{#1}}
 \newcommand{\CSLIndent}[1]{\hspace{\cslhangindent}#1}
 $endif$
-% LS 25-11-2020 end of addition to solve bug
 
 %%% Use protect on footnotes to avoid problems with footnotes in titles
 \let\rmarkdownfootnote\footnote%

--- a/inst/rmarkdown/templates/thesis/skeleton/template.tex
+++ b/inst/rmarkdown/templates/thesis/skeleton/template.tex
@@ -204,6 +204,34 @@ $if(dir)$
 \fi
 $endif$
 
+% LS 25-11-2020 add new statement similar to thesisdown bugfix:
+% https://github.com/ismayc/thesisdown/pull/79#issue-384204665
+% LS 25-11-2020 note: fix didn't work: I went to the raw pandoc version and copied and pasted the following lines.
+% copied from https://github.com/jgm/pandoc/blob/master/data/templates/default.latex
+$if(csl-refs)$
+\newlength{\cslhangindent}
+\setlength{\cslhangindent}{1.5em}
+\newlength{\csllabelwidth}
+\setlength{\csllabelwidth}{3em}
+\newenvironment{CSLReferences}[2] % #1 hanging-ident, #2 entry spacing
+ {% don't indent paragraphs
+  \setlength{\parindent}{0pt}
+  % turn on hanging indent if param 1 is 1
+  \ifodd #1 \everypar{\setlength{\hangindent}{\cslhangindent}}\ignorespaces\fi
+  % set entry spacing
+  \ifnum #2 > 0
+  \setlength{\parskip}{#2\baselineskip}
+  \fi
+ }%
+ {}
+\usepackage{calc}
+\newcommand{\CSLBlock}[1]{#1\hfill\break}
+\newcommand{\CSLLeftMargin}[1]{\parbox[t]{\csllabelwidth}{#1}}
+\newcommand{\CSLRightInline}[1]{\parbox[t]{\linewidth - \csllabelwidth}{#1}\break}
+\newcommand{\CSLIndent}[1]{\hspace{\cslhangindent}#1}
+$endif$
+% LS 25-11-2020 end of addition to solve bug
+
 %%% Use protect on footnotes to avoid problems with footnotes in titles
 \let\rmarkdownfootnote\footnote%
 \def\footnote{\protect\rmarkdownfootnote}


### PR DESCRIPTION
Hi Leon, Thanks for making this template! I am trying to adjust it for a Groningen university thesis. I came across this error regarding csl references after upgrading to the latest Rstudio (v1.4). This change in the template fixed it for me. Please check it yourself before accepting, my Latex knowledge is limited.

The error occurs in pandoc v2.8 and higher, due to a change in pandoc and its standard .tex template. See also https://github.com/ismayc/thesisdown/pull/79#issue-384204665