### PR TITLE
Make it possible to use biblatex with the template

### DIFF
--- a/inst/rmarkdown/templates/thesis/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/thesis/skeleton/skeleton.Rmd
@@ -93,11 +93,11 @@ output:
   bookdown::pdf_book: 
     template: template.tex
     keep_tex: yes
-    #pandoc_args: [ "--csl", "apa.csl" ] # download the citation style of your choice from https://www.zotero.org/styles, then fill in here
+    #pandoc_args: [ "--csl", "apa.csl" ] # download the citation style of your choice from
+    citation_package: none # to use .csl-files to apply same citation style to html and pdf. You can also use a LaTeX package, e.g. biblatex. This provides much more customizability, but it is not as easy to apply a particular style, and it will only work in pdf output. https://www.zotero.org/styles, then fill in here
 indent: true # indent new paragraphs, instead of leaving whitespace
 links-as-notes: true # in the pdf, print hyperlink URLS as footnotes (as they can't be clicked on)
 bibliography: thesis.bib # bib-file containing bibliographic information on all works you want to cite
-citation_package: none # to use .csl-files to apply same citation style to html and pdf. You can also use a LaTeX package, e.g. biblatex. This provides much more customizability, but it is not as easy to apply a particular style, and it will only work in pdf output.
 link-citations: true # make clickable hyperlinks from in-text citations to bibliography at the end
 ---
 

--- a/inst/rmarkdown/templates/thesis/skeleton/thesis.bib
+++ b/inst/rmarkdown/templates/thesis/skeleton/thesis.bib
@@ -1,73 +1,19 @@
 
- @article{cite:12,
-  author = {T. Wilson and A. Y. Sasaki},
-  title = {Ultra-Globally Co-{G}aussian, Sub-Stochastic, Natural Fields and Discrete Representation Theory},
-  journal = {{J}ournal of Modern Constructive Potential Theory},
-  month = aug,
-  year = 2011,
-  volume = 33,
-  pages = {158--190}}
-
-
- @article{cite:5,
-  author = {C. Williams and T. Zhou and E. Bose},
-  title = {Finitely Commutative, Characteristic, Holomorphic Arrows over Functions},
-  journal = {{J}ournal of Homological Analysis},
-  month = feb,
-  year = 1995,
-  volume = 94,
-  pages = {45--53}}
-
-@book {cite:3,
+@book {Miller2009,
     author = {U. Y. Miller and Y. Borel},
      title = {Convex Algebra},
      publisher = {Cambridge University Press},
       year = {2009},
      pages = {6801}}
 
-@book {cite:8,
-    author = {O. Shastri and W. Sato},
-     title = {Quantum Mechanics},
-     publisher = {Wiley},
-      year = {2000},
-     pages = {34}}
-
-@book {cite:33,
-    author = {C. Newton },
-     title = {Introduction to Descriptive Probability},
+@book {Brown2003,
+    author = {C. Brown },
+     title = {A First Course in Integral Analysis},
      publisher = {Prentice Hall},
-      year = {1991},
-     pages = {221}}
+      year = {2003},
+     pages = {997}}
 
-
- @article{cite:4,
-  author = {V. B. Huygens and O. Zhou},
-  title = {Integrability Methods in Quantum {L}ie Theory},
-  journal = {{B}ulletin of the {L}ebanese {M}athematical {S}ociety},
-  month = jun,
-  year = 2007,
-  volume = 46,
-  pages = {58--64}}
-
-
- @article{cite:21,
-  author = {G. O. Garcia and J. L. Dedekind},
-  title = {Degeneracy in Non-Standard Analysis},
-  journal = {{P}roceedings of the {B}urundian {M}athematical {S}ociety},
-  month = apr,
-  year = 2001,
-  volume = 73,
-  pages = {1405--1429}}
-
-@book {cite:16,
-    author = {F. Sato },
-     title = {Universal Representation Theory with Applications to General Graph Theory},
-     publisher = {Slovak Mathematical Society},
-      year = {2009},
-     pages = {82}}
-
-
- @article{cite:31,
+ @article{White1994,
   author = {D. White and Z. Thomas and B. Raman},
   title = {Measurability in Algebraic Algebra},
   journal = {{J}ournal of Integral Model Theory},
@@ -76,8 +22,7 @@
   volume = 32,
   pages = {55--61}}
 
-
- @article{cite:14,
+ @article{Miller2002,
   author = {Q. Miller },
   title = {Integrable, Contra-Partially {M}arkov Factors for a Sub-Multiply Ultra-{M}ilnor, Composite, Completely Sub-Integral System},
   journal = {{L}ithuanian {J}ournal of Non-Commutative Dynamics},
@@ -86,18 +31,7 @@
   volume = 37,
   pages = {153--191}}
 
-
- @article{cite:23,
-  author = {A. Lastname and C. Maruyama},
-  title = {Null, Globally Contra-Hyperbolic, Holomorphic Points for a Ring},
-  journal = {{A}nnals of the {I}ndian {M}athematical {S}ociety},
-  month = nov,
-  year = 1992,
-  volume = 71,
-  pages = {75--99}}
-
-
- @article{cite:30,
+ @article{Lee1997,
   author = {T. Lee and C. Martin},
   title = {Groups and Singular Combinatorics},
   journal = {{J}ournal of Global Arithmetic},
@@ -106,124 +40,21 @@
   volume = 0,
   pages = {1--50}}
 
-
- @article{cite:15,
-  author = {A. Lastname and K. G\"odel},
-  title = {Left-Freely Extrinsic Fields and {E}uclidean Potential Theory},
-  journal = {{B}urmese {J}ournal of Formal Combinatorics},
-  month = aug,
-  year = 2007,
-  volume = 81,
-  pages = {308--399}}
-
-
- @article{cite:1,
-  author = {E. Garcia and C. Taylor},
-  title = {On the Derivation of Positive, Positive Definite Curves},
-  journal = {{J}ournal of Numerical Potential Theory},
-  month = jul,
-  year = 1990,
-  volume = 6,
-  pages = {80--109}}
-
-@book {cite:6,
-    author = {K. Johnson },
-     title = {Non-Linear Knot Theory},
-     publisher = {Elsevier},
-      year = {2008},
-     pages = {28}}
-
-@book {cite:13,
-    author = {B. Eisenstein },
-     title = {General Calculus},
-     publisher = {McGraw Hill},
-      year = {1993},
-     pages = {24}}
-
-@book {cite:24,
-    author = {J. B. Raman },
-     title = {Parabolic Potential Theory},
-     publisher = {Wiley},
-      year = {1953},
-     pages = {9102}}
-
-@book {cite:2,
-    author = {C. Brown },
-     title = {A First Course in Integral Analysis},
-     publisher = {Prentice Hall},
-      year = {2003},
-     pages = {997}}
-
-
- @article{cite:19,
-  author = {W. Davis and S. K. Martin},
-  title = {{E}rd{\H{o}}s, One-to-One Functionals of Onto, Ultra-{A}tiyah, Right-Analytically {H}eaviside Functors and Connectedness Methods},
-  journal = {{T}ransactions of the {S}omali {M}athematical {S}ociety},
-  month = nov,
-  year = 1999,
-  volume = 95,
-  pages = {201--266}}
-
-@book {cite:32,
-    author = {A. Lastname },
-     title = {Abstract Calculus},
-     publisher = {De Gruyter},
-      year = {1994},
-     pages = {34}}
-
-
- @article{cite:7,
-  author = {W. Bhabha },
-  title = {On Stochastic Model Theory},
-  journal = {{J}ournal of Global Knot Theory},
-  month = feb,
-  year = 2009,
-  volume = 21,
-  pages = {1400--1485}}
-
-@book {cite:0,
-    author = {A. Lastname and R. Lobachevsky},
-     title = {A First Course in Symbolic Mechanics},
-     publisher = {Oxford University Press},
-      year = {1998},
-     pages = {829}}
-
-@book {cite:10,
+@book {Kobayashi1994,
     author = {E. G. Kobayashi },
      title = {Elliptic {K}-Theory},
      publisher = {De Gruyter},
       year = {1994},
      pages = {56}}
 
-
- @article{cite:27,
-  author = {A. Lastname and C. Zhou and C. Russell},
-  title = {On the Classification of Naturally Ultra-Countable, Admissible Classes},
-  journal = {{I}rish {M}athematical {B}ulletin},
-  month = mar,
-  year = 1995,
-  volume = 93,
-  pages = {207--228}}
-
-
- @article{cite:25,
-  author = {I. Nehru and B. Tate},
-  title = {Essentially Prime Continuity for Simply Continuous Monoids},
-  journal = {{J}ournal of Spectral Topology},
-  month = nov,
-  year = 2006,
-  volume = 12,
-  pages = {303--323}}
-
-@book {cite:18,
+@book {Moore2011,
     author = {T. Moore },
      title = {Dynamics with Applications to Non-Linear Analysis},
      publisher = {Cambridge University Press},
       year = {2011},
      pages = {15}}
 
-
- @article{cite:22,
+ @article{Zhou2007,
   author = {I. Zhou and A. Gupta},
   title = {Some Uniqueness Results for Additive, Countably Composite Random Variables},
   journal = {{S}lovenian {J}ournal of Higher Microlocal Algebra},
@@ -232,42 +63,7 @@
   volume = 46,
   pages = {1--85}}
 
-@book {cite:28,
-    author = {R. Anderson },
-     title = {Non-Commutative Logic},
-     publisher = {Prentice Hall},
-      year = {1991},
-     pages = {6595}}
-
-
- @article{cite:20,
-  author = {J. Miller and Z. Grothendieck},
-  title = {Admissibility in Global Mechanics},
-  journal = {{J}ournal of Theoretical Topology},
-  month = oct,
-  year = 2011,
-  volume = 37,
-  pages = {200--238}}
-
-
- @article{cite:26,
-  author = {Z. Monge and T. Fr\'echet and N. Davis},
-  title = {Algebraically {C}lairaut Polytopes and Descriptive Topology},
-  journal = {{J}ournal of Geometric Algebra},
-  month = apr,
-  year = 1993,
-  volume = 92,
-  pages = {207--266}}
-
-@book {cite:11,
-    author = {E. Levi-Civita and W. Maruyama and Q. Zhou},
-     title = {Advanced Measure Theory with Applications to Constructive Category Theory},
-     publisher = {Springer},
-      year = {1995},
-     pages = {331}}
-
-
- @article{cite:29,
+ @article{Lee1999,
   author = {X. Lee and A. Lastname},
   title = {Smoothly Connected Reducibility for Separable Lines},
   journal = {{B}elarusian {M}athematical {A}rchives},
@@ -277,7 +73,7 @@
   pages = {1401--1442}}
 
 
- @article{cite:17,
+ @article{Garcia1998,
   author = {K. Garcia },
   title = {Functions over Local Homeomorphisms},
   journal = {{O}ceanian {J}ournal of Classical Potential Theory},
@@ -287,7 +83,7 @@
   pages = {84--107}}
 
 
- @article{cite:9,
+ @article{Zhao1986,
   author = {I. Zhao },
   title = {On {K}lein's Conjecture},
   journal = {{I}ranian {J}ournal of Local Category Theory},
@@ -374,11 +170,8 @@ year = {2017}
 author = {Reynolds, P S.},
 booktitle = {Case Studies in Biometry},
 chapter = {11},
-editor = {Lange, N., Ryan, L., Billard, L., Brillinger, D., Conquest, L., Greenhouse, J.},
+editor = {Lange, N. and Ryan, L. and Billard, L. and Brillinger, D. and Conquest, L. and Greenhouse, J.},
 publisher = {New York: John Wiley and Sons},
 title = {{Time-series analyses of beaver body temperatures}},
 year = {1994}
 }
-
-
-


### PR DESCRIPTION
Using biblatex as the citation package did not work, because the option was not specified correctly in the YAML, and because the example bibliography in `thesis.bib` could not be processed correctly.

Relevant to #7.